### PR TITLE
AcceptContentTypes per source, Fix isValidJson issue with arrays

### DIFF
--- a/configs/gleaner_opencore
+++ b/configs/gleaner_opencore
@@ -1,0 +1,45 @@
+context:
+    cache: true
+contextmaps:
+    - file: ./assets/schemaorg-current-https.jsonld
+      prefix: https://schema.org/
+    - file: ./assets/schemaorg-current-http.jsonld
+      prefix: http://schema.org/
+gleaner:
+    mill: true
+    runid: runX
+    summon: true
+millers:
+    graph: true
+minio:
+    address: oss.geocodes-dev.earthcube.org
+    port: 443
+    ssl: true
+    accesskey: worldsbestaccesskey
+    secretkey: worldsbestsecretkey
+    bucket: opencore
+sources:
+    - sourcetype: sitemap
+      name: opencoredata
+      logo: https://opencoredata.org/img/logo22small.png
+      url: http://opencoredata.org/sitemap.xml
+      headless: false
+      pid: https://www.re3data.org/repository/r3d100012874
+      propername: opencoredata
+      domain: https://opencoredata.org/
+      active: true
+      credentialsfile: ""
+      other: {}
+      headlesswait: 0
+      delay: 1
+      identifierpath: ""
+      apipagelimit: 0
+      identifiertype: identifiersha
+      fixcontextoption: 0
+      acceptcontenttype: "application/ld+json"
+summoner:
+    after: ""
+    delay: null
+    headless: http://127.0.0.1:9222
+    mode: full
+    threads: 15

--- a/internal/config/sources.go
+++ b/internal/config/sources.go
@@ -32,6 +32,7 @@ const (
 	StandardizedHttps
 	StandardizedHttp
 )
+const AccceptContentType string = "application/ld+json, text/html"
 
 func (s ContextOption) String() string {
 	switch s {
@@ -70,12 +71,14 @@ type Sources struct {
 	// SitemapFormat string
 	// Active        bool
 
-	HeadlessWait     int    // if loading is slow, wait
-	Delay            int64  // A domain-specific crawl delay value
-	IdentifierPath   string // JSON Path to the identifier
-	ApiPageLimit     int
-	IdentifierType   string
-	FixContextOption ContextOption
+	HeadlessWait       int    // if loading is slow, wait
+	Delay              int64  // A domain-specific crawl delay value
+	IdentifierPath     string // JSON Path to the identifier
+	ApiPageLimit       int
+	IdentifierType     string
+	FixContextOption   ContextOption
+	AccceptContentType string // accept content type string for http request
+	JsonProfile        string // jsonprofile
 }
 
 // add needed for file
@@ -89,29 +92,33 @@ type SourcesConfig struct {
 	Domain     string
 	// SitemapFormat string
 	// Active        bool
-	HeadlessWait     int    // is loading is slow, wait
-	Delay            int64  // A domain-specific crawl delay value
-	IdentifierPath   string // JSON Path to the identifier
-	IdentifierType   string
-	FixContextOption ContextOption
+	HeadlessWait       int    // is loading is slow, wait
+	Delay              int64  // A domain-specific crawl delay value
+	IdentifierPath     string // JSON Path to the identifier
+	IdentifierType     string
+	FixContextOption   ContextOption
+	AccceptContentType string // accept content type string for http request
+	JsonProfile        string // jsonprofile
 }
 
 var SourcesTemplate = map[string]interface{}{
 	"sources": map[string]string{
-		"sourcetype":       "sitemap",
-		"name":             "",
-		"url":              "",
-		"logo":             "",
-		"headless":         "",
-		"pid":              "",
-		"propername":       "",
-		"domain":           "",
-		"credentialsfile":  "",
-		"headlesswait":     "0",
-		"delay":            "0",
-		"identifierpath":   "",
-		"identifiertype":   JsonSha,
-		"fixcontextoption": "https",
+		"sourcetype":        "sitemap",
+		"name":              "",
+		"url":               "",
+		"logo":              "",
+		"headless":          "",
+		"pid":               "",
+		"propername":        "",
+		"domain":            "",
+		"credentialsfile":   "",
+		"headlesswait":      "0",
+		"delay":             "0",
+		"identifierpath":    "",
+		"identifiertype":    JsonSha,
+		"fixcontextoption":  "https",
+		"acceptcontenttype": "application/ld+json, text/html",
+		"jsonprofile":       "",
 	},
 }
 

--- a/internal/config/sources.go
+++ b/internal/config/sources.go
@@ -71,14 +71,14 @@ type Sources struct {
 	// SitemapFormat string
 	// Active        bool
 
-	HeadlessWait       int    // if loading is slow, wait
-	Delay              int64  // A domain-specific crawl delay value
-	IdentifierPath     string // JSON Path to the identifier
-	ApiPageLimit       int
-	IdentifierType     string
-	FixContextOption   ContextOption
-	AccceptContentType string // accept content type string for http request
-	JsonProfile        string // jsonprofile
+	HeadlessWait      int    // if loading is slow, wait
+	Delay             int64  // A domain-specific crawl delay value
+	IdentifierPath    string // JSON Path to the identifier
+	ApiPageLimit      int
+	IdentifierType    string
+	FixContextOption  ContextOption
+	AcceptContentType string `default:"application/ld+json, text/html"` // accept content type string for http request
+	JsonProfile       string // jsonprofile
 }
 
 // add needed for file
@@ -92,13 +92,13 @@ type SourcesConfig struct {
 	Domain     string
 	// SitemapFormat string
 	// Active        bool
-	HeadlessWait       int    // is loading is slow, wait
-	Delay              int64  // A domain-specific crawl delay value
-	IdentifierPath     string // JSON Path to the identifier
-	IdentifierType     string
-	FixContextOption   ContextOption
-	AccceptContentType string // accept content type string for http request
-	JsonProfile        string // jsonprofile
+	HeadlessWait      int    // is loading is slow, wait
+	Delay             int64  // A domain-specific crawl delay value
+	IdentifierPath    string // JSON Path to the identifier
+	IdentifierType    string
+	FixContextOption  ContextOption
+	AcceptContentType string `default:"application/ld+json, text/html"` // accept content type string for http request
+	JsonProfile       string // jsonprofile
 }
 
 var SourcesTemplate = map[string]interface{}{
@@ -125,6 +125,12 @@ var SourcesTemplate = map[string]interface{}{
 func populateDefaults(s Sources) Sources {
 	if s.SourceType == "" {
 		s.SourceType = "sitemap"
+	}
+	if s.AcceptContentType == "" {
+		s.AcceptContentType = "application/ld+json, text/html"
+	}
+	if s.JsonProfile == "" {
+		s.JsonProfile = "application/ld+json"
 	}
 	// fix issues, too. Space from CSV causing url errors
 	s.URL = strings.TrimSpace(s.URL)

--- a/internal/summoner/acquire/acquire.go
+++ b/internal/summoner/acquire/acquire.go
@@ -74,7 +74,7 @@ func getConfig(v1 *viper.Viper, sourceName string) (string, int, int64, int, str
 	// look for a domain specific override crawl delay
 	sources, err := configTypes.GetSources(v1)
 	source, err := configTypes.GetSourceByName(sources, sourceName)
-	acceptContent := source.AccceptContentType
+	acceptContent := source.AcceptContentType
 	jsonProfile := source.JsonProfile
 	hw := source.HeadlessWait
 	if err != nil {
@@ -149,7 +149,30 @@ func getDomain(v1 *viper.Viper, mc *minio.Client, urls []string, sourceName stri
 			defer resp.Body.Close()
 
 			jsonlds, err := FindJSONInResponse(v1, urlloc, jsonProfile, repologger, resp)
-
+			// there was an issue with sitemaps... but now this code
+			//if contains(contentTypeHeader, JSONContentType) || contains(contentTypeHeader, "application/json") {
+			//
+			//	b, err := io.ReadAll(resp.Body)
+			//	// b, err := ioutil.ReadAll(resp.Body)  Go.1.15 and earlier
+			//	if err != nil {
+			//		log.Error("#", i, " error on ", urlloc, err) // print an message containing the index (won't keep order)
+			//		repoStats.Inc(common.Issues)
+			//		lwg.Done() // tell the wait group that we be done
+			//		<-semaphoreChan
+			//		return
+			//	}
+			//	jsonlds = []string{string(b)}
+			//} else {
+			//	var err error
+			//	jsonlds, err = FindJSONInResponse(v1, urlloc, jsonProfile, repologger, resp)
+			//	if err != nil {
+			//		log.Error("#", i, " error on ", urlloc, err) // print an message containing the index (won't keep order)
+			//		repoStats.Inc(common.Issues)
+			//		lwg.Done() // tell the wait group that we be done
+			//		<-semaphoreChan
+			//		return
+			//	}
+			//}
 			if err != nil {
 				log.Error("#", i, " error on ", urlloc, err) // print an message containing the index (won't keep order)
 				repoStats.Inc(common.Issues)

--- a/internal/summoner/acquire/acquire.go
+++ b/internal/summoner/acquire/acquire.go
@@ -237,8 +237,8 @@ func FindJSONInResponse(v1 *viper.Viper, urlloc string, jsonProfile string, repo
 		logFields := log.Fields{"url": urlloc, "contentType": "json or ld_json"}
 		repologger.WithFields(logFields).Debug()
 		log.WithFields(logFields).Debug(urlloc, " as ", contentTypeHeader)
-
-		jsonlds, err = addToJsonListIfValid(v1, jsonlds, doc.Text())
+		resp_text := doc.Text()
+		jsonlds, err = addToJsonListIfValid(v1, jsonlds, resp_text)
 		if err != nil {
 			log.WithFields(logFields).Error("Error processing json response from ", urlloc, err)
 			repologger.WithFields(logFields).Error(err)

--- a/internal/summoner/acquire/acquire_test.go
+++ b/internal/summoner/acquire/acquire_test.go
@@ -28,7 +28,7 @@ func TestGetConfig(t *testing.T) {
 		}
 
 		viper := ConfigSetupHelper(conf)
-		bucketName, tc, delay, err := getConfig(viper, "testSource")
+		bucketName, tc, delay, _, _, _, err := getConfig(viper, "testSource")
 		assert.Equal(t, "test", bucketName)
 		assert.Equal(t, 5, tc)
 		assert.Equal(t, int64(0), delay)
@@ -43,7 +43,7 @@ func TestGetConfig(t *testing.T) {
 		}
 
 		viper := ConfigSetupHelper(conf)
-		bucketName, tc, delay, err := getConfig(viper, "testSource")
+		bucketName, tc, delay, _, _, _, err := getConfig(viper, "testSource")
 		assert.Equal(t, "test", bucketName)
 		assert.Equal(t, 1, tc)
 		assert.Equal(t, int64(1000), delay)
@@ -58,7 +58,7 @@ func TestGetConfig(t *testing.T) {
 		}
 
 		viper := ConfigSetupHelper(conf)
-		bucketName, tc, delay, err := getConfig(viper, "testSource")
+		bucketName, tc, delay, _, _, _, err := getConfig(viper, "testSource")
 		assert.Equal(t, "test", bucketName)
 		assert.Equal(t, 5, tc)
 		assert.Equal(t, int64(0), delay)
@@ -73,7 +73,7 @@ func TestGetConfig(t *testing.T) {
 		}
 
 		viper := ConfigSetupHelper(conf)
-		bucketName, tc, delay, err := getConfig(viper, "testSource")
+		bucketName, tc, delay, _, _, _, err := getConfig(viper, "testSource")
 		assert.Equal(t, "test", bucketName)
 		assert.Equal(t, 1, tc)
 		assert.Equal(t, int64(100), delay)
@@ -88,7 +88,7 @@ func TestGetConfig(t *testing.T) {
 		}
 
 		viper := ConfigSetupHelper(conf)
-		bucketName, tc, delay, err := getConfig(viper, "testSource")
+		bucketName, tc, delay, _, _, _, err := getConfig(viper, "testSource")
 		assert.Equal(t, "test", bucketName)
 		assert.Equal(t, 1, tc)
 		assert.Equal(t, int64(50), delay)
@@ -102,7 +102,7 @@ func TestFindJSONInResponse(t *testing.T) {
 	}
 	viper := ConfigSetupHelper(conf)
 	logger := log.New()
-
+	const JSONContentType = "application/ld+json"
 	testJson := `{
 	    "@graph":[
 	        {
@@ -128,7 +128,7 @@ func TestFindJSONInResponse(t *testing.T) {
 	}
 
 	t.Run("It returns an error if the response document cannot be parsed", func(t *testing.T) {
-		result, err := FindJSONInResponse(viper, urlloc, logger, nil)
+		result, err := FindJSONInResponse(viper, urlloc, JSONContentType, logger, nil)
 		assert.Nil(t, result)
 		assert.Equal(t, errors.New("Response is nil"), err)
 	})
@@ -140,7 +140,7 @@ func TestFindJSONInResponse(t *testing.T) {
 		response.ContentLength = int64(len(html))
 		var expected []string
 
-		result, err := FindJSONInResponse(viper, urlloc, logger, response)
+		result, err := FindJSONInResponse(viper, urlloc, JSONContentType, logger, response)
 		assert.Nil(t, err)
 		assert.Equal(t, result, append(expected, testJson))
 	})
@@ -150,7 +150,7 @@ func TestFindJSONInResponse(t *testing.T) {
 		response.ContentLength = int64(len(testJson))
 		var expected []string
 
-		result, err := FindJSONInResponse(viper, "test.json", logger, response)
+		result, err := FindJSONInResponse(viper, "test.json", JSONContentType, logger, response)
 		assert.Nil(t, err)
 		assert.Equal(t, result, append(expected, testJson))
 	})
@@ -161,7 +161,7 @@ func TestFindJSONInResponse(t *testing.T) {
 		response.Header.Add("Content-Type", JSONContentType)
 		var expected []string
 
-		result, err := FindJSONInResponse(viper, urlloc, logger, response)
+		result, err := FindJSONInResponse(viper, urlloc, JSONContentType, logger, response)
 		assert.Nil(t, err)
 		assert.Equal(t, result, append(expected, testJson))
 	})
@@ -172,7 +172,7 @@ func TestFindJSONInResponse(t *testing.T) {
 		response.Header.Add("Content-Type", "application/json; charset=utf-8")
 		var expected []string
 
-		result, err := FindJSONInResponse(viper, urlloc, logger, response)
+		result, err := FindJSONInResponse(viper, urlloc, JSONContentType, logger, response)
 		assert.Nil(t, err)
 		assert.Equal(t, result, append(expected, testJson))
 	})

--- a/internal/summoner/acquire/api.go
+++ b/internal/summoner/acquire/api.go
@@ -57,7 +57,7 @@ func RetrieveAPIData(apiSources []configTypes.Sources, mc *minio.Client, runStat
 
 func getAPISource(v1 *viper.Viper, mc *minio.Client, source configTypes.Sources, wg *sync.WaitGroup, repologger *log.Logger, repoStats *common.RepoStats) {
 
-	bucketName, tc, delay, _, err := getConfig(v1, source.Name) // _ is headless wait
+	bucketName, tc, delay, _, acceptContent, jsonProfile, err := getConfig(v1, source.Name) // _ is headless wait
 	if err != nil {
 		// trying to read a source, so let's not kill everything with a panic/fatal
 		log.Error("Error reading config file ", err)
@@ -92,8 +92,8 @@ func getAPISource(v1 *viper.Viper, mc *minio.Client, source configTypes.Sources,
 				log.Error(i, err, urlloc)
 			}
 			req.Header.Set("User-Agent", EarthCubeAgent)
-			req.Header.Set("Accept", "application/ld+json, text/html")
-
+			//req.Header.Set("Accept", "application/ld+json, text/html")
+			req.Header.Set("Accept", acceptContent)
 			response, err := client.Do(req)
 
 			if err != nil {
@@ -116,7 +116,7 @@ func getAPISource(v1 *viper.Viper, mc *minio.Client, source configTypes.Sources,
 			log.Trace("Response status ", response.StatusCode, " from ", urlloc)
 			responseStatusChan <- response.StatusCode
 
-			jsonlds, err := FindJSONInResponse(v1, urlloc, repologger, response)
+			jsonlds, err := FindJSONInResponse(v1, urlloc, jsonProfile, repologger, response)
 
 			if err != nil {
 				log.Error("#", i, " error on ", urlloc, err) // print an message containing the index (won't keep order)

--- a/internal/summoner/acquire/headlessNG.go
+++ b/internal/summoner/acquire/headlessNG.go
@@ -292,7 +292,7 @@ func PageRender(v1 *viper.Viper, timeout time.Duration, url, k string, repologge
 	expressionTmpl := `
 		function getMetadata() {
 			return new Promise((resolve, reject) => {
-				const elements = document.querySelectorAll('script[type="application/ld+json"]');
+				const elements = document.querySelectorAll('script[type^="application/ld+json"]');
 				let metadata = [];
 				elements.forEach(function(element) {
 					if(element && element.innerText) {

--- a/internal/summoner/acquire/jsonutils.go
+++ b/internal/summoner/acquire/jsonutils.go
@@ -43,7 +43,7 @@ func isGraphArray(v1 *viper.Viper, jsonld string) (bool, []string, error) {
 	var myArray []interface{}
 	err := json.Unmarshal([]byte(jsonld), &myArray)
 	if err == nil {
-		var myArray []interface{}
+		var myArray []map[string]interface{}
 		err := json.Unmarshal([]byte(jsonld), &myArray)
 		if err == nil {
 			for _, j := range myArray {

--- a/internal/summoner/acquire/jsonutils.go
+++ b/internal/summoner/acquire/jsonutils.go
@@ -36,10 +36,13 @@ func isValid(v1 *viper.Viper, jsonld string) (bool, error) {
 	proc, options := common.JLDProc(v1)
 
 	var myInterface map[string]interface{}
-
 	err := json.Unmarshal([]byte(jsonld), &myInterface)
 	if err != nil {
-		return false, fmt.Errorf("Error in unmarshaling json: %s", err)
+		var myArray []interface{}
+		err := json.Unmarshal([]byte(jsonld), &myArray)
+		if err != nil {
+			return false, fmt.Errorf("Error in unmarshaling json: %s", err)
+		}
 	}
 
 	_, err = proc.ToRDF(myInterface, options) // returns triples but toss them, just validating
@@ -158,7 +161,7 @@ func fixId(jsonld string) (string, error) {
 	var formatter func(index int) string
 	if topLevelType == "Dataset" {
 		selector = "@id"
-		formatter = func(index int) string { return "@id"}
+		formatter = func(index int) string { return "@id" }
 	} else if topLevelType == "ItemList" {
 		selector = "itemListElement.#.item.@id"
 		formatter = func(index int) string { return fmt.Sprintf("itemListElement.%v.item.@id", index) }
@@ -173,7 +176,7 @@ func fixId(jsonld string) (string, error) {
 		idUrl, idErr := url.Parse(jsonIdentifier)
 		if idUrl.Scheme == "" { // we have a relative url and no base in the context
 			log.Trace("Transforming id: ", jsonIdentifier, " to file:// url because it is relative")
-			jsonld, idErr = sjson.Set(jsonld, formatter(index), "file://" + jsonIdentifier)
+			jsonld, idErr = sjson.Set(jsonld, formatter(index), "file://"+jsonIdentifier)
 		} else {
 			log.Trace("JSON-LD context base or IRI id found: ", originalBase, "ID: ", idUrl)
 		}

--- a/resoruces/jsonld/opencore_csdco_icdfiles.jsonld
+++ b/resoruces/jsonld/opencore_csdco_icdfiles.jsonld
@@ -1,0 +1,74 @@
+[
+  {
+    "@graph": [
+      {
+        "@id": "_:bbj6sl3ntr9b9lop9uoig",
+        "@type": [
+          "https://schema.org/PropertyValue"
+        ],
+        "https://schema.org/propertyID": [
+          {
+            "@value": "SHA256"
+          }
+        ],
+        "https://schema.org/value": [
+          {
+            "@value": "000355176249738e6b0530130d21c9051c30b1ca865bd52b2ee75343e9986c73"
+          }
+        ]
+      },
+      {
+        "@id": "https://opencoredata.org/id/csdco/do/000355176249738e6b0530130d21c9051c30b1ca865bd52b2ee75343e9986c73",
+        "@type": [
+          "http://www.schema.org/DigitalDocument"
+        ],
+        "https://schema.org/additionType": [
+          {
+            "@id": "https://opencoredata.org/voc/csdco/v1/ICDFiles"
+          }
+        ],
+        "https://schema.org/dateCreated": [
+          {
+            "@value": "2004-03-10"
+          }
+        ],
+        "https://schema.org/description": [
+          {
+            "@value": "Digital object of type ICD named GLAD2-LT01-2A-13H-2.pdf for CSDCO project GLAD2"
+          }
+        ],
+        "https://schema.org/encodingFormat": [
+          {
+            "@value": "application/pdf"
+          }
+        ],
+        "https://schema.org/identifier": [
+          {
+            "@id": "_:bbj6sl3ntr9b9lop9uoig"
+          }
+        ],
+        "https://schema.org/isRelatedTo": [
+          {
+            "@value": "GLAD2"
+          }
+        ],
+        "https://schema.org/license": [
+          {
+            "@id": "http://example.com/cc0.html"
+          }
+        ],
+        "https://schema.org/name": [
+          {
+            "@value": "GLAD2-LT01-2A-13H-2.pdf"
+          }
+        ],
+        "https://schema.org/url": [
+          {
+            "@id": "https://opencoredata.org/id/csdco/do/000355176249738e6b0530130d21c9051c30b1ca865bd52b2ee75343e9986c73"
+          }
+        ]
+      }
+    ],
+    "@id": "https://opencoredata.org/objectgraph/id/000355176249738e6b0530130d21c9051c30b1ca865bd52b2ee75343e9986c73"
+  }
+]


### PR DESCRIPTION
Preps for JSON Profiles, by setting up acceptcontenttype and jsonprfile properties on sources

fixes the if is array is valid JSON issue.

Does not fix the need that like aquadocs we may need to split these things up into individual files.